### PR TITLE
fix for unable to find compressibleTransportModel.h

### DIFF
--- a/Make/options
+++ b/Make/options
@@ -2,6 +2,7 @@ EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
     -I$(LIB_SRC)/thermophysicalModels/specie/lnInclude \
+    -I$(LIB_SRC)/transportModels/compressible/compressibleTransportModel \
     -I$(LIB_SRC)/meshTools/lnInclude
 
 LIB_LIBS = \


### PR DESCRIPTION
I was unable to compile the package with OF3.0.1 without a slight modification of the options file.  
